### PR TITLE
Use requests.get(...) instead of os.system("wget ..."), add progress counter, and add support for backslash path separator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scipy
 torchmetrics==0.11.3
 torchvision #==0.13.1
 pretrainedmodels #==0.7.4
+requests


### PR DESCRIPTION
This pull request will make demo.py fully support Windows. It was tested on a clean install of Windows 11, and it should work on Windows 10 as well, since Windows 11 is Windows 10 with a few aesthetic changes. That's not a jab at Microsoft, that's a true fact.